### PR TITLE
Patch missing information on the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,15 @@ and `sed` directly into the projects' tree structure.
 
 To install `giphon`, simply run:
 
-```shq
+```sh
 pip install --user giphon
+```
+
+And if you wish to use giphon by simply calling `giphon`, you can set-up an 
+alias in your `.bashrc` (or other, if you have another shell):
+
+```sh
+echo 'alias giphon="/usr/bin/env python3 -m giphon"' >> ~/.bashrc
 ```
 
 ## Parameters


### PR DESCRIPTION
## Problem

The `gif` image illustrating how to use the CLI is not coherent with the rest of the documentation. In order for it to be coherent, we need to specify in the setup documentation that `giphon` needs an alias for it to be available as a bare command.