### PR TITLE
feat: Add a means to source environment variables into bash

### DIFF
--- a/src/giphon/__about__.py
+++ b/src/giphon/__about__.py
@@ -1,5 +1,5 @@
 __title__ = "Gitlab Siphon"
-__version__ = "0.1.8"
+__version__ = "0.2.0"
 __author__ = "Gabriel Creti"
 __license__ = "Apache"
 __copywrite__ = "Copyright (C) 2022 Gabriel Creti <gabrielcreti@gmail.com>"

--- a/src/giphon/__main__.py
+++ b/src/giphon/__main__.py
@@ -2,10 +2,12 @@
 
 from typer import Typer
 
+from .envvars import source
 from .siphon import siphon
 
 if __name__ == "__main__":
     app = Typer(no_args_is_help=True, add_completion=False)
 
     app.command()(siphon)
+    app.command(name="source")(source)
     app()

--- a/src/giphon/envvars.py
+++ b/src/giphon/envvars.py
@@ -1,0 +1,98 @@
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote_plus
+
+from typer import Argument, Option
+
+REGEX_SPECIAL_CHARACTERS = (
+    "\\.+?^$()[]{}|"  # NOTE: backslash needs to go first as it escapes others
+)
+
+
+def source(
+    environment: str = Argument(
+        "...",
+        help="The target environment to load variables from.",
+    ),
+    path: Path = Option(
+        Path("."),
+        help="The path to load the environment variables from.",
+    ),
+) -> None:
+    """
+    Print sourceable exports of environment, with upwards recursion.
+    """
+
+    current_path = path.resolve()
+
+    parent_pile = [current_path]
+
+    while current_path != Path("/"):
+        current_path = current_path.parent
+        parent_pile.append(current_path)
+
+    try:
+        while True:
+            _source_specific_path(
+                environment=environment, path=parent_pile.pop()
+            )
+
+    except IndexError:
+        return
+
+
+def _source_specific_path(environment: str, path: Path) -> None:
+    """
+    Print sourceable exports of environment, for a given directory.
+    """
+
+    variables_path = path / Path(".gitlab/.env")
+    env_paths = [path for path in variables_path.glob("*") if path.is_file()]
+
+    for env_path in env_paths:
+        try:
+            (env_type, env_name, env_escaped_scope) = env_path.name.split(":")
+        except ValueError:
+            print(f"Error: badly formatted file `{env_path}`", file=sys.stderr)
+
+            continue
+
+        env_scope = unquote_plus(env_escaped_scope)
+
+        if not _match_environment_to_scope(
+            environment=environment, scope=env_scope
+        ):
+            continue
+
+        if env_type == "file":
+            value = env_path.resolve()
+
+        elif env_type == "env_var":
+            with open(env_path) as f:
+                value = f.read()
+
+        else:
+            raise NotImplementedError(f"Unsupported variable type {env_type}")
+
+        print(f"export {env_name}='{value}'")
+
+
+def _match_environment_to_scope(environment: str, scope: str) -> bool:
+    """
+    Check if a given environment string matches a given scope wildcard.
+
+    Allowed wildcards are "*".
+
+    Args:
+        environment (string): The environment to match
+        scope (string): The target scope
+    """
+    scope_regex = scope
+
+    for char in REGEX_SPECIAL_CHARACTERS:
+        scope_regex = scope_regex.replace(char, rf"\{char}")
+
+    scope_regex = scope_regex.replace("*", ".*")
+
+    return bool(re.match(scope_regex, environment))

--- a/src/giphon/envvars.py
+++ b/src/giphon/envvars.py
@@ -66,7 +66,7 @@ def _source_specific_path(environment: str, path: Path) -> None:
             continue
 
         if env_type == "file":
-            value = env_path.resolve()
+            value = str(env_path.resolve())
 
         elif env_type == "env_var":
             with open(env_path) as f:

--- a/src/giphon/gitlab.py
+++ b/src/giphon/gitlab.py
@@ -2,6 +2,7 @@ import os
 from logging import Logger
 from pathlib import Path
 from typing import Generator, List, Union
+from urllib.parse import quote_plus
 
 from gitlab import Gitlab
 from gitlab.base import RESTObject
@@ -25,9 +26,8 @@ def save_environment_variables(
     """
 
     def _save_environment_variable(variable: Variable, env_path: Path) -> None:
-        scope = variable.environment_scope
-
-        key = f'{variable.key}-{scope.replace("*", "STAR").replace("/", "-")}'
+        escaped_scope = quote_plus(variable.environment_scope)
+        key = f"{variable.variable_type}:{variable.key}:{escaped_scope}"
 
         with open(os.path.join(env_path, f"{key}"), "w") as f:
             f.write(variable.value)

--- a/src/giphon/siphon.py
+++ b/src/giphon/siphon.py
@@ -106,27 +106,6 @@ def siphon(
     This function traverses recursively a Gitlab instance or group in order to
     copy locally all of the project's repositories and their environment
     variables, while keeping the arborescence.
-
-    Args:
-        namespace (Path): The Gitlab namespace to recusively siphon.
-          Use `/` to siphon the instance.
-        output (Path): The target path to clone the repositories to.", ).
-        gitlab_token (str): The Personal Access Token for the Gitlab v4 API."
-        gitlab_url (str): The URL for the Gitlab Instance. Defaults to
-          "https://gitlab.com".
-        fetch_repositories (bool, optional): Whether to fetch remotes on
-          repositories that already exist. Defaults to True.
-        save_ci_variables (bool, optional): Whether to download CI/CD
-          variables to a .env directory.. Defaults to True.
-        clone_archived (bool, optional): Whether to clone archived repository.
-          Defaults to False.
-        clone_through_ssh (bool, optional): Whether to clone using ssh or
-          https.
-        gitlab_username: (str, optional): The username to use when cloning
-          through https.
-        verbose (bool, optional): Whether the outputs should be verbose.
-          Defaults to False.
-
     """
     logger = _setup_logger(
         __name__, logging.INFO if verbose <= 0 else logging.DEBUG

--- a/tests/test_envvars.py
+++ b/tests/test_envvars.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for the siphon module.
+
+Integration test for the main function.
+"""
+
+
+from giphon.envvars import (
+    _match_environment_to_scope,
+    source,
+)
+
+
+def test_match_environment_to_scope():
+    # Regular successful tests
+    assert (
+        _match_environment_to_scope(environment="env/dev", scope="env/dev")
+        is True
+    )
+    assert (
+        _match_environment_to_scope(environment="env/dev", scope="env/*")
+        is True
+    )
+
+    assert (
+        _match_environment_to_scope(environment="env/dev", scope="*/dev")
+        is True
+    )
+
+    # Test unmatching wildcards
+    assert (
+        _match_environment_to_scope(environment="env/dev", scope="toto/*")
+        is False
+    )
+
+    # Test another separation token
+    assert (
+        _match_environment_to_scope(environment="env+dev", scope="env+*")
+        is True
+    )
+
+    # Test: not a regular regex
+    assert (
+        _match_environment_to_scope(environment="env/dev", scope="env/.*")
+        is False
+    )
+
+
+# def test_match_environment_to_scope():
+#    TODO: setup a fake directory structure with hierarchy and test variables
+# are imported in the correct order
+#     source_environment_variables

--- a/tests/test_envvars.py
+++ b/tests/test_envvars.py
@@ -5,10 +5,7 @@ Integration test for the main function.
 """
 
 
-from giphon.envvars import (
-    _match_environment_to_scope,
-    source,
-)
+from giphon.envvars import _match_environment_to_scope
 
 
 def test_match_environment_to_scope():
@@ -46,7 +43,9 @@ def test_match_environment_to_scope():
     )
 
 
-# def test_match_environment_to_scope():
-#    TODO: setup a fake directory structure with hierarchy and test variables
-# are imported in the correct order
-#     source_environment_variables
+def test_source():
+    """
+    TODO: setup a fake directory structure with hierarchy and test variables
+    are printed in the correct order.
+    """
+    ...

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import gitlab
 import pytest
-
 from giphon.gitlab import (
     flatten_groups_tree,
     get_gitlab_element_full_path,
@@ -281,13 +280,13 @@ def test_save_environment_variables(monkeypatch):
         assert output == (
             "Would have made the path random_path/the_group/.gitlab/.env\n"
             "Entered mock open with args ('random_path/the_group/.gitlab/.env/"
-            "ipsum-lorem', 'w') and kwargs {}\n"
+            "file:ipsum:lorem', 'w') and kwargs {}\n"
             "Would have written dolor\n"
             "Entered mock open with args ('random_path/the_group/.gitlab/.env/"
-            "ipsum-lorem', 'w') and kwargs {}\n"
+            "env_var:ipsum:lorem', 'w') and kwargs {}\n"
             "Would have written dolor\n"
             "Entered mock open with args ('random_path/the_group/.gitlab/.env/"
-            "ipsum-lorem', 'w') and kwargs {}\n"
+            "file:ipsum:lorem', 'w') and kwargs {}\n"
             "Would have written dolor\n"
         )
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import gitlab
 import pytest
+
 from giphon.gitlab import (
     flatten_groups_tree,
     get_gitlab_element_full_path,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -131,14 +131,15 @@ class MockGitlabVariables:
         if self.list_must_error:
             raise GitlabListError
         return [
-            _MockGitlabVariable(),
-            _MockGitlabVariable(),
-            _MockGitlabVariable(),
+            _MockGitlabVariable(variable_type="file"),
+            _MockGitlabVariable(variable_type="env_var"),
+            _MockGitlabVariable(variable_type="file"),
         ]
 
 
 class _MockGitlabVariable:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, variable_type: str, *args, **kwargs):
         self.environment_scope = "lorem"
         self.key = "ipsum"
         self.value = "dolor"
+        self.variable_type = variable_type


### PR DESCRIPTION
## Breaking

- Changed format of saved environment variables into `env_type:env_name:env_scope`
  Since scopes contain characters that are incompatible with POSIX file paths, we'll escape them with url encode

## Feature

- Be able to generate a shell script's text that export all of the environment variables, recursively starting from the top.
  This will allow anyone with one single line of command (`source <(python3 -m giphon source $ENV)`) to load their current shell environment with whatever variables their corresponding Gitlab-CI has.